### PR TITLE
Add a way to set custom patterns

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,15 @@ noTestShortcuts({
   // Defines the behavior for handling skipped tests (e.g. test.skip()).
   // Defaults to 'ignore'.
   // Valid values: 'ignore', 'fail', 'warn'.
-  skippedTests: 'fail'
+  skippedTests: 'fail',
+
+  // Defines any (additional) patterns you want to test for
+  // Defaults to no extra patterns
+  // Here you can add patterns specific to how your test framework does skips/onlys
+  patterns: {
+    only: ['customOnly'],
+    skip: ['sk.ip']
+  }
 })
 ```
 
@@ -41,4 +49,4 @@ Run the tests with `yarn test` (uses [Jest](https://facebook.github.io/jest/)).
 
 This project uses [semantic-release](https://github.com/semantic-release/semantic-release) for automated NPM package publishing.
 
-The main caveat: instead of running `git commit`, run `yarn commit` and follow the prompts to input a conventional changelog message via [commitizen](https://github.com/commitizen/cz-cli). 
+The main caveat: instead of running `git commit`, run `yarn commit` and follow the prompts to input a conventional changelog message via [commitizen](https://github.com/commitizen/cz-cli).

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,6 +1,10 @@
 interface Config {
   testFilePredicate?: (filePath: string) => boolean
   skippedTests?: 'ignore' | 'warn' | 'fail'
+  patterns?: {
+    only?: string[]
+    skip?: string[]
+  }
 }
 
 export default function noTestShortcuts(): void

--- a/src/__tests__/index.test.js
+++ b/src/__tests__/index.test.js
@@ -167,4 +167,51 @@ describe('noTestShortcuts()', () => {
       })
     })
   })
+  describe('config: patterns', () => {
+    const MOCK_FILE_INFO = {
+      'tests/index.test.js': 'test.on.ly',
+      'tests/subdirectory/myTest.js': 'test.sk.ip'
+    }
+    beforeEach(() => {
+      require('fs').__setMockFiles(MOCK_FILE_INFO)
+      global.fail = jest.fn()
+    })
+    afterEach(() => {
+      global.danger = undefined
+      global.fail = undefined
+    })
+
+    it('allows people to set custom only assertion patterns', () => {
+      global.danger = {
+        git: {
+          created_files: ['tests/index.test.js'],
+          modified_files: []
+        }
+      }
+      noTestShortcuts({
+        patterns: {only: ['on.ly']}
+      })
+
+      expect(global.fail).toHaveBeenCalledWith(
+        'an `only` was left in tests: tests/index.test.js'
+      )
+    })
+
+    it('allows people to set custom skip assertion patterns', () => {
+      global.danger = {
+        git: {
+          created_files: ['tests/subdirectory/myTest.js'],
+          modified_files: []
+        }
+      }
+      noTestShortcuts({
+        skippedTests: 'fail',
+        patterns: {skip: ['sk.ip']}
+      })
+
+      expect(global.fail).toHaveBeenCalledWith(
+        'a `skip` was left in tests: tests/subdirectory/myTest.js'
+      )
+    })
+  })
 })

--- a/src/__tests__/index.test.js
+++ b/src/__tests__/index.test.js
@@ -29,7 +29,7 @@ describe('noTestShortcuts()', () => {
       })
 
       expect(global.fail).toHaveBeenCalledWith(
-        'an `only` was left in tests: path/to/tests/index.test.js'
+        'a `describe.only` was left in tests: path/to/tests/index.test.js'
       )
     })
     it('defaults to the tests/ directory', () => {
@@ -43,7 +43,7 @@ describe('noTestShortcuts()', () => {
       noTestShortcuts()
 
       expect(global.fail).toHaveBeenCalledWith(
-        'an `only` was left in tests: tests/subdirectory/myTest.js'
+        'a `describe.only` was left in tests: tests/subdirectory/myTest.js'
       )
     })
   })
@@ -76,7 +76,7 @@ describe('noTestShortcuts()', () => {
       })
 
       expect(global.fail).toHaveBeenCalledWith(
-        'a `skip` was left in tests: tests/skip.test.js'
+        'a `test.skip` was left in tests: tests/skip.test.js'
       )
     })
     it('warns when skippedTests: "warn" is passed in', () => {
@@ -92,7 +92,7 @@ describe('noTestShortcuts()', () => {
       })
 
       expect(global.warn).toHaveBeenCalledWith(
-        'a `skip` was left in tests: tests/skip.test.js'
+        'a `test.skip` was left in tests: tests/skip.test.js'
       )
     })
     it('does not warn when skippedTests: "warn" is passed in and test contains .only()', () => {
@@ -163,7 +163,7 @@ describe('noTestShortcuts()', () => {
         noTestShortcuts()
 
         expect(global.fail)
-          .toHaveBeenCalledWith(`an \`only\` was left in tests: tests/${testFn}.test.js`)
+          .toHaveBeenCalledWith(`${testFn === 'it' ? 'an' : 'a'} \`${testFn}.only\` was left in tests: tests/${testFn}.test.js`)
       })
     })
   })
@@ -193,7 +193,7 @@ describe('noTestShortcuts()', () => {
       })
 
       expect(global.fail).toHaveBeenCalledWith(
-        'an `only` was left in tests: tests/index.test.js'
+        'an `on.ly` was left in tests: tests/index.test.js'
       )
     })
 
@@ -210,7 +210,7 @@ describe('noTestShortcuts()', () => {
       })
 
       expect(global.fail).toHaveBeenCalledWith(
-        'a `skip` was left in tests: tests/subdirectory/myTest.js'
+        'a `sk.ip` was left in tests: tests/subdirectory/myTest.js'
       )
     })
   })

--- a/src/__tests__/test.ts
+++ b/src/__tests__/test.ts
@@ -13,6 +13,17 @@ noTestShortcuts({
 })
 
 noTestShortcuts({
+  patterns: {
+    only: ['on.ly'],
+    skip: ['todo'],
+  },
+})
+
+noTestShortcuts({
   testFilePredicate: (filePath: string) => filePath.indexOf('.test.js') >= -1,
-  skippedTests: 'fail'
+  skippedTests: 'fail',
+  patterns: {
+    only: ['on.ly'],
+    skip: ['todo'],
+  },
 })

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,8 @@
 import {readFileSync} from 'fs'
 
+const getStart = pattern =>
+  ['a', 'e', 'i', 'o', 'u'].includes(pattern[0].toLowerCase()) ? 'an' : 'a'
+
 export default function noTestShortcuts (
   {
     testFilePredicate = path => path.startsWith('tests'),
@@ -13,34 +16,35 @@ export default function noTestShortcuts (
   const newOrModifiedTests = newOrModifiedFiles.filter(testFilePredicate)
   for (const file of newOrModifiedTests) {
     const content = readFileSync(file).toString()
-    const onlyPatternsResult = patterns.only && patterns.only.length > 0
-      ? patterns.only.map(p => content.includes(p)).includes(true)
-      : false
-    if (
-      content.includes('context.only') ||
-      content.includes('describe.only') ||
-      content.includes('test.only') ||
-      content.includes('it.only') ||
-      onlyPatternsResult
-    ) {
-      fail(`an \`only\` was left in tests: ${file}`)
+    const allPatterns = [
+      'context.only',
+      'describe.only',
+      'test.only',
+      'it.only'
+    ].concat(patterns.only || [])
+    const match = allPatterns.find(p => content.includes(p))
+
+    if (match) {
+      fail(`${getStart(match)} \`${match}\` was left in tests: ${file}`)
     }
     switch (skippedTests) {
       case 'ignore':
         break
       case 'fail':
       case 'warn':
-        const skipPatternsResult = patterns.skip && patterns.skip.length > 0
-          ? patterns.skip.map(p => content.includes(p)).includes(true)
-          : false
-        if (
-          content.includes('context.skip') ||
-          content.includes('describe.skip') ||
-          content.includes('test.skip') ||
-          content.includes('it.skip') ||
-          skipPatternsResult
-        ) {
-          global[skippedTests](`a \`skip\` was left in tests: ${file}`)
+        const skipPatternsResult = (patterns.skip || [])
+          .find(p => content.includes(p))
+        const skipPatterns = [
+          'context.skip',
+          'describe.skip',
+          'test.skip',
+          'it.skip'
+        ].concat(patterns.skip || [])
+        const skipMatch = skipPatterns.find(p => content.includes(p))
+        if (skipMatch) {
+          global[
+            skippedTests
+          ](`${getStart(skipMatch)} \`${skipMatch}\` was left in tests: ${file}`)
         }
         break
       default:

--- a/src/index.js
+++ b/src/index.js
@@ -3,7 +3,8 @@ import {readFileSync} from 'fs'
 export default function noTestShortcuts (
   {
     testFilePredicate = path => path.startsWith('tests'),
-    skippedTests = 'ignore'
+    skippedTests = 'ignore',
+    patterns = {only: [], skip: []}
   } = {}
 ) {
   const newOrModifiedFiles = danger.git.modified_files.concat(
@@ -12,11 +13,15 @@ export default function noTestShortcuts (
   const newOrModifiedTests = newOrModifiedFiles.filter(testFilePredicate)
   for (const file of newOrModifiedTests) {
     const content = readFileSync(file).toString()
+    const onlyPatternsResult = patterns.only && patterns.only.length > 0
+      ? patterns.only.map(p => content.includes(p)).includes(true)
+      : false
     if (
       content.includes('context.only') ||
       content.includes('describe.only') ||
       content.includes('test.only') ||
-      content.includes('it.only')
+      content.includes('it.only') ||
+      onlyPatternsResult
     ) {
       fail(`an \`only\` was left in tests: ${file}`)
     }
@@ -25,11 +30,15 @@ export default function noTestShortcuts (
         break
       case 'fail':
       case 'warn':
+        const skipPatternsResult = patterns.skip && patterns.skip.length > 0
+          ? patterns.skip.map(p => content.includes(p)).includes(true)
+          : false
         if (
           content.includes('context.skip') ||
           content.includes('describe.skip') ||
           content.includes('test.skip') ||
-          content.includes('it.skip')
+          content.includes('it.skip') ||
+          skipPatternsResult
         ) {
           global[skippedTests](`a \`skip\` was left in tests: ${file}`)
         }


### PR DESCRIPTION
If your testing framework doesn't use the same format, or, with Ava for example, you import the `test` function with a different name, none of the checks will work.

This allows people to add (only additional) patterns to be checked, too.