### PR TITLE
feat: require testFilePredicate

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,10 +13,12 @@
 Import and invoke the `noTestShortcuts()` function in your Dangerfile:
 
 ```js
-// dangerfile.js or dangerfile.ts
+// dangerfile.js
 import noTestShortcuts from 'danger-plugin-no-test-shortcuts'
 
-noTestShortcuts()
+noTestShortcuts({
+  testFilePredicate: (filePath) => filePath.endsWith('.test.js'),
+})
 ```
 
 By default, Danger will fail the build if a new or modified test file contains `.only()` - this prevents merging changes that will prevent your entire test suite from running on each pull request.
@@ -25,8 +27,7 @@ This plugin takes an optional config object with a couple of options:
 
 ```js
 noTestShortcuts({
-  // A predicate for determining where your test files live.
-  // Defaults to file paths that start with 'tests' (e.g. tests/index.spec.js).
+  // A required predicate for determining where your test files live.
   testFilePredicate: (filePath) => filePath.endsWith('.test.js'),
 
   // Defines the behavior for handling skipped tests (e.g. test.skip()).

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,23 +2,44 @@ import { readFileSync } from 'fs'
 import * as _ from 'lodash'
 
 export interface Config {
-  testFilePredicate?: (filePath: string) => boolean
+  /**
+   * A predicate for determining where your test files live.
+   *
+   * Example:
+   * ```
+   * // Filters all files that end with '.test.js'.
+   * testFilePredicate: (filePath) => filePath.endsWith('.test.js')
+   * ```
+   */
+  testFilePredicate: (filePath: string) => boolean
+  /**
+   * Defines the danger function to call for skipped tests (e.g. `test.skip()`).
+   * Defaults to 'ignore', which will not invoke any danger function.
+   * Valid values: 'ignore', 'fail', 'warn'.
+   */
   skippedTests?: 'ignore' | 'warn' | 'fail'
+  /**
+   * Defines any additional patterns you want to search for in your test files.
+   * Defaults to no extra patterns.
+   * Here you can add patterns specific to how your test framework does skips/onlys.
+   */
   patterns?: {
     only?: string[]
     skip?: string[]
   }
 }
 
-const getStart = (pattern: string) =>
+const getStart = (pattern: string): string =>
   _.includes(['a', 'e', 'i', 'o', 'u'], pattern[0].toLowerCase()) ? 'an' : 'a'
 
-export default function noTestShortcuts(config: Config = {}) {
-  const {
-    testFilePredicate = (path: string): boolean => path.startsWith('tests'),
-    skippedTests = 'ignore',
-    patterns = { only: [], skip: [] },
-  } = config
+export default function noTestShortcuts({
+  testFilePredicate,
+  skippedTests = 'ignore',
+  patterns = { only: [], skip: [] },
+}: Config) {
+  if (!testFilePredicate) {
+    throw new Error('Must supply testFilePredicate()')
+  }
 
   const newOrModifiedFiles: string[] = danger.git.modified_files
     .concat(danger.git.created_files)


### PR DESCRIPTION
This commit changes the `testFilePredicate()` from optional to required. You must now supply the
proper `testFilePredicate()` that applies to your codebase. For example:

```js
noTestShortcuts({
  testFilePredicate: (filePath) => filePath.endsWith('.test.js'),
})
```

BREAKING CHANGE: This may require updating usages of `noTestShortcuts()` to ensure a
`testFilePredicate()` is passed into its configuration object parameter.